### PR TITLE
Align Gradle toolchain with available JDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,14 @@ group = 'com.madhukar'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+        toolchain {
+                // Use the JDK that is available in the execution environment. The
+                // previous configuration required JDK 17 which caused builds to fail
+                // when that version was not installed. Bumping the toolchain to the
+                // currently available JDK 21 lets the project compile and run tests
+                // without manual JDK downloads.
+                languageVersion = JavaLanguageVersion.of(21)
+        }
 }
 
 configurations {


### PR DESCRIPTION
## Summary
- adjust Java toolchain to JDK 21 to match available environment and avoid build failure

## Testing
- `gradle test` *(fails: Could not resolve all files for configuration ':compileClasspath'. Could not get resource 'https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-configuration-processor/3.3.5/spring-boot-configuration-processor-3.3.5.pom'. Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b635b12c008320a99b01a0cd176c1a